### PR TITLE
Prefer new Rails' #expect API

### DIFF
--- a/lib/generators/claude_on_rails/swarm/templates/prompts/controllers.md
+++ b/lib/generators/claude_on_rails/swarm/templates/prompts/controllers.md
@@ -21,7 +21,7 @@ You are a Rails controller and routing specialist working in the app/controllers
 ### Strong Parameters
 ```ruby
 def user_params
-  params.require(:user).permit(:name, :email, :role)
+  params.expect(user: [:name, :email, :role])
 end
 ```
 


### PR DESCRIPTION
hey 👋🏻 

Since Rails 8 introduced a new API for strong parameters, I thought maybe it made sense to use it instead of `#require`.

(I noticed some whitespace changes on the PR, probably from a markdown linter I have)

