### PR TITLE
Update link to rails-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,4 @@ MIT License - see [LICENSE](./LICENSE) for details.
 
 - Powered by [claude-swarm](https://github.com/parruda/claude-swarm)
 - Built for [Claude Code](https://github.com/anthropics/claude-code)
-- Integrates with [Rails MCP Server](https://github.com/mariochavez/rails-mcp-server)
+- Integrates with [Rails MCP Server](https://github.com/maquina-app/rails-mcp-server)


### PR DESCRIPTION
The link to rails-mcp-server is broken. 
I get a 404 when clicking it. 
I found this project https://github.com/maquina-app/rails-mcp-server Im assuming its the correct one.