### PR TITLE
fix agent prompt creation logic when generating test template 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2025-07-03
+
+### Fixed
+- Fixed tests prompt not being rendered correctly
+
 ## [0.2.0] - 2025-01-02
 
 ### Added

--- a/lib/generators/claude_on_rails/swarm/swarm_generator.rb
+++ b/lib/generators/claude_on_rails/swarm/swarm_generator.rb
@@ -89,7 +89,22 @@ module ClaudeOnRails
 
       def create_agent_prompts
         say 'Setting up agent-specific prompts...', :green
-        directory 'prompts', '.claude-on-rails/prompts'
+
+        dest_dir = '.claude-on-rails/prompts'
+        empty_directory dest_dir
+
+        Dir[File.join(self.class.source_root, 'prompts', '*')].each do |source_path|
+          filename = File.basename(source_path)
+          relative_source = File.join('prompts', filename)
+          destination_filename = filename.sub(/\.erb\z/, '')
+          destination_path = File.join(dest_dir, destination_filename)
+
+          if filename.end_with?('.erb')
+            template relative_source, destination_path
+          else
+            copy_file relative_source, destination_path
+          end
+        end
       end
 
       def update_gitignore

--- a/lib/generators/claude_on_rails/swarm/templates/prompts/tests.md.erb
+++ b/lib/generators/claude_on_rails/swarm/templates/prompts/tests.md.erb
@@ -23,10 +23,10 @@ RSpec.describe User, type: :model do
     it { should validate_presence_of(:email) }
     it { should validate_uniqueness_of(:email).case_insensitive }
   end
-  
+
   describe '#full_name' do
     let(:user) { build(:user, first_name: 'John', last_name: 'Doe') }
-    
+
     it 'returns the combined first and last name' do
       expect(user.full_name).to eq('John Doe')
     end
@@ -39,13 +39,13 @@ end
 RSpec.describe 'Users API', type: :request do
   describe 'GET /api/v1/users' do
     let!(:users) { create_list(:user, 3) }
-    
+
     before { get '/api/v1/users', headers: auth_headers }
-    
+
     it 'returns all users' do
       expect(json_response.size).to eq(3)
     end
-    
+
     it 'returns status code 200' do
       expect(response).to have_http_status(200)
     end
@@ -58,13 +58,13 @@ end
 RSpec.describe 'User Registration', type: :system do
   it 'allows a user to sign up' do
     visit new_user_registration_path
-    
+
     fill_in 'Email', with: 'test@example.com'
     fill_in 'Password', with: 'password123'
     fill_in 'Password confirmation', with: 'password123'
-    
+
     click_button 'Sign up'
-    
+
     expect(page).to have_content('Welcome!')
     expect(User.last.email).to eq('test@example.com')
   end
@@ -79,7 +79,7 @@ class UserTest < ActiveSupport::TestCase
     user = User.new
     assert_not user.save, "Saved the user without an email"
   end
-  
+
   test "should report full name" do
     user = User.new(first_name: "John", last_name: "Doe")
     assert_equal "John Doe", user.full_name
@@ -93,17 +93,17 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   setup do
     @user = users(:one)
   end
-  
+
   test "should get index" do
     get users_url
     assert_response :success
   end
-  
+
   test "should create user" do
     assert_difference('User.count') do
       post users_url, params: { user: { email: 'new@example.com' } }
     end
-    
+
     assert_redirected_to user_url(User.last)
   end
 end


### PR DESCRIPTION
When running `rails generate claude_on_rails:swarm`, I've noticed that the `tests.md` contained both RSpec and Minitest templates. 

This PR aims to fix that - I've changed the `tests.md` to `tests.md.erb` and added some logic around these filetypes in the `create_agent_prompts` method.

```
❯ rubocop -A
Inspecting 16 files
................

16 files inspected, no offenses detected
                                                                           
❯ rspec

ClaudeOnRails::ProjectAnalyzer
  #analyze
    returns a hash with expected keys
    with a standard Rails app
      detects it's not API-only
    with an API-only Rails app
      detects API-only configuration
    test framework detection
      detects RSpec
      detects Minitest
      returns nil when no test framework is found
    gem detection
      with GraphQL
        detects GraphQL
      with Turbo
        detects Turbo
      with Devise
        detects Devise
    custom patterns detection
      detects service objects directory
      detects form objects directory

Finished in 0.00774 seconds (files took 0.15276 seconds to load)
11 examples, 0 failures
```