### PR TITLE
Fix Rails MCP Server link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Customize agent behavior by editing prompts in `.claude-on-rails/prompts/`:
 
 ## Enhanced Documentation with Rails MCP Server
 
-ClaudeOnRails integrates with [Rails MCP Server](https://github.com/mariochavez/rails-mcp-server) to provide your AI agents with real-time access to Rails documentation and best practices.
+ClaudeOnRails integrates with [Rails MCP Server](https://github.com/maquina-app/rails-mcp-server) to provide your AI agents with real-time access to Rails documentation and best practices.
 
 ### Benefits
 


### PR DESCRIPTION
## Summary
Fixed broken link to fast-mcp-server in upper portion of the README.md. The link in the Acknowledgements section is correct.

## Changes
- Updated link from [https://github.com/mariochavez/rails-mcp-server](https://github.com/mariochavez/rails-mcp-server) to [https://github.com/maquina-app/rails-mcp-server](https://github.com/maquina-app/rails-mcp-server) 

## Issue
The existing link was returning a 404 incorrectly and preventing users from accessing the rails-mcp-server repository.

## Testing
- [x] Verified new link works correctly
- [x] Checked that link opens to expected content