### PR TITLE
fix: remove additional newlines generated in claude-swarm.yml

### DIFF
--- a/lib/generators/claude_on_rails/swarm/templates/swarm.yml.erb
+++ b/lib/generators/claude_on_rails/swarm/templates/swarm.yml.erb
@@ -2,7 +2,7 @@ version: 1
 swarm:
   name: "<%= Rails.application.class.module_parent_name %> Rails Development Team"
   main: architect
-<% if @include_mcp_server %>
+<%- if @include_mcp_server -%>
   mcps:
     - name: rails
       type: stdio
@@ -10,13 +10,13 @@ swarm:
       args: []
       env:
         RAILS_ENV: <%= Rails.env %>
-<% if @include_dev_mcp %>
+<%- if @include_dev_mcp -%>
     - name: rails-dev
       type: stdio
       command: rails-dev-mcp
       args: []
-<% end %>
-<% end %>
+<%- end -%>
+<%- end -%>
   instances:
     architect:
       description: "Rails architect coordinating <%= @api_only ? 'API' : 'full-stack' %> development for <%= Rails.application.class.module_parent_name %>"
@@ -25,105 +25,105 @@ swarm:
       connections: [<%= agents.reject { |a| a == 'architect' }.join(', ') %>]
       prompt_file: .claude-on-rails/prompts/architect.md
       vibe: true
-<% if File.directory?(Rails.root.join("app/models")) %>
-    
+<%- if File.directory?(Rails.root.join("app/models")) -%>
+
     models:
       description: "ActiveRecord models, migrations, and database optimization specialist"
       directory: ./app/models
       model: opus
       allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
       prompt_file: .claude-on-rails/prompts/models.md
-<% end %>
-<% if File.directory?(Rails.root.join("app/controllers")) %>
-      
+<%- end -%>
+<%- if File.directory?(Rails.root.join("app/controllers")) -%>
+
     controllers:
       description: "Rails controllers, routing, and request handling specialist"
       directory: ./app/controllers
       model: opus
-<% connections = [] %>
-<% connections << 'services' if File.directory?(Rails.root.join("app/services")) %>
-<% connections << 'api' if @api_only && File.directory?(Rails.root.join("app/controllers/api")) %>
-<% if connections.any? %>
+<%- connections = [] -%>
+<%- connections << 'services' if File.directory?(Rails.root.join("app/services")) -%>
+<%- connections << 'api' if @api_only && File.directory?(Rails.root.join("app/controllers/api")) -%>
+<%- if connections.any? -%>
       connections: [<%= connections.join(', ') %>]
-<% end %>
+<%- end -%>
       allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
       prompt_file: .claude-on-rails/prompts/controllers.md
-<% end %>
-<% if !@api_only && File.directory?(Rails.root.join("app/views")) %>
-    
+<%- end -%>
+<%- if !@api_only && File.directory?(Rails.root.join("app/views")) -%>
+
     views:
       description: "Rails views, layouts, partials, and asset pipeline specialist"
       directory: ./app/views
       model: opus
-<% if @has_turbo && File.directory?(Rails.root.join("app/javascript")) %>
+<%- if @has_turbo && File.directory?(Rails.root.join("app/javascript")) -%>
       connections: [stimulus]
-<% end %>
+<%- end -%>
       allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
       prompt_file: .claude-on-rails/prompts/views.md
-<% end %>
-<% if @api_only && File.directory?(Rails.root.join("app/controllers/api")) %>
-    
+<%- end -%>
+<%- if @api_only && File.directory?(Rails.root.join("app/controllers/api")) -%>
+
     api:
       description: "RESTful API design, serialization, and versioning specialist"
       directory: ./app/controllers/api
       model: opus
       allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
       prompt_file: .claude-on-rails/prompts/api.md
-<% end %>
-<% if @has_graphql && File.directory?(Rails.root.join("app/graphql")) %>
-    
+<%- end -%>
+<%- if @has_graphql && File.directory?(Rails.root.join("app/graphql")) -%>
+
     graphql:
       description: "GraphQL schema, resolvers, and mutations specialist"
       directory: ./app/graphql
       model: opus
       allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
       prompt_file: .claude-on-rails/prompts/graphql.md
-<% end %>
-<% if @has_turbo && File.directory?(Rails.root.join("app/javascript")) %>
-    
+<%- end -%>
+<%- if @has_turbo && File.directory?(Rails.root.join("app/javascript")) -%>
+
     stimulus:
       description: "Stimulus.js controllers and Turbo integration specialist"
       directory: ./app/javascript
       model: opus
       allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
       prompt_file: .claude-on-rails/prompts/stimulus.md
-<% end %>
-<% if File.directory?(Rails.root.join("app/services")) %>
-    
+<%- end -%>
+<%- if File.directory?(Rails.root.join("app/services")) -%>
+
     services:
       description: "Service objects, business logic, and design patterns specialist"
       directory: ./app/services
       model: opus
       allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
       prompt_file: .claude-on-rails/prompts/services.md
-<% end %>
-<% if File.directory?(Rails.root.join("app/jobs")) %>
-      
+<%- end -%>
+<%- if File.directory?(Rails.root.join("app/jobs")) -%>
+
     jobs:
       description: "Background jobs, ActiveJob, and async processing specialist"
       directory: ./app/jobs
       model: opus
       allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
       prompt_file: .claude-on-rails/prompts/jobs.md
-<% end %>
-<% if !@skip_tests %>
-<% test_dir = @test_framework == 'RSpec' ? 'spec' : 'test' %>
-<% if File.directory?(Rails.root.join(test_dir)) %>
-    
+<%- end -%>
+<%- if !@skip_tests -%>
+<%- test_dir = @test_framework == 'RSpec' ? 'spec' : 'test' -%>
+<%- if File.directory?(Rails.root.join(test_dir)) -%>
+
     tests:
       description: "<%= @test_framework %> testing, factories, and test coverage specialist"
       directory: ./<%= test_dir %>
       model: opus
       allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
       prompt_file: .claude-on-rails/prompts/tests.md
-<% end %>
-<% end %>
-<% if File.directory?(Rails.root.join("config")) %>
-    
+<%- end -%>
+<%- end -%>
+<%- if File.directory?(Rails.root.join("config")) -%>
+
     devops:
       description: "Deployment, Docker, CI/CD, and production configuration specialist"
       directory: ./config
       model: opus
       allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
       prompt_file: .claude-on-rails/prompts/devops.md
-<% end %>
+<%- end -%>


### PR DESCRIPTION
## Summary
I tried out `claude-on-rails` for the first time tonight and noticed the spacing in the `claude-swarm.yml` was off. This PR fixes the spacing by using trim erb tags.

I noticed there were explicit new lines within some of the `if` blocks, and assumed they might have been added to increase readability between agents, so I left those in but also happy to remove these if those were not intentional as part of this PR. If we do choose to remove those new lines, I will also update the README to reflect the removal of these lines.

## Testing
I chose not to write any specific specs, and rather test in a new rails app. Below are the files generated before and after this change.

### Before
```
version: 1
swarm:
  name: "TestApp Rails Development Team"
  main: architect

  mcps:
    - name: rails
      type: stdio
      command: rails-mcp-server
      args: []
      env:
        RAILS_ENV: development

  instances:
    architect:
      description: "Rails architect coordinating full-stack development for TestApp"
      directory: .
      model: opus
      connections: [models, controllers, views, stimulus, jobs, tests, devops]
      prompt_file: .claude-on-rails/prompts/architect.md
      vibe: true

    
    models:
      description: "ActiveRecord models, migrations, and database optimization specialist"
      directory: ./app/models
      model: opus
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/models.md


      
    controllers:
      description: "Rails controllers, routing, and request handling specialist"
      directory: ./app/controllers
      model: opus




      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/controllers.md


    
    views:
      description: "Rails views, layouts, partials, and asset pipeline specialist"
      directory: ./app/views
      model: opus

      connections: [stimulus]

      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/views.md




    
    stimulus:
      description: "Stimulus.js controllers and Turbo integration specialist"
      directory: ./app/javascript
      model: opus
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/stimulus.md



      
    jobs:
      description: "Background jobs, ActiveJob, and async processing specialist"
      directory: ./app/jobs
      model: opus
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/jobs.md




    
    tests:
      description: "Minitest testing, factories, and test coverage specialist"
      directory: ./test
      model: opus
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/tests.md



    
    devops:
      description: "Deployment, Docker, CI/CD, and production configuration specialist"
      directory: ./config
      model: opus
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/devops.md
```

### After
```
version: 1
swarm:
  name: "TestApp Rails Development Team"
  main: architect
  mcps:
    - name: rails
      type: stdio
      command: rails-mcp-server
      args: []
      env:
        RAILS_ENV: development
  instances:
    architect:
      description: "Rails architect coordinating full-stack development for TestApp"
      directory: .
      model: opus
      connections: [models, controllers, views, stimulus, jobs, tests, devops]
      prompt_file: .claude-on-rails/prompts/architect.md
      vibe: true

    models:
      description: "ActiveRecord models, migrations, and database optimization specialist"
      directory: ./app/models
      model: opus
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/models.md

    controllers:
      description: "Rails controllers, routing, and request handling specialist"
      directory: ./app/controllers
      model: opus
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/controllers.md

    views:
      description: "Rails views, layouts, partials, and asset pipeline specialist"
      directory: ./app/views
      model: opus
      connections: [stimulus]
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/views.md

    stimulus:
      description: "Stimulus.js controllers and Turbo integration specialist"
      directory: ./app/javascript
      model: opus
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/stimulus.md

    jobs:
      description: "Background jobs, ActiveJob, and async processing specialist"
      directory: ./app/jobs
      model: opus
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/jobs.md

    tests:
      description: "Minitest testing, factories, and test coverage specialist"
      directory: ./test
      model: opus
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/tests.md

    devops:
      description: "Deployment, Docker, CI/CD, and production configuration specialist"
      directory: ./config
      model: opus
      allowed_tools: [Read, Edit, Write, Bash, Grep, Glob, LS]
      prompt_file: .claude-on-rails/prompts/devops.md

```